### PR TITLE
グループ作成画面　項目名の変更

### DIFF
--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -7,7 +7,7 @@
           %li= message 
   .chat-group-form__field
     .chat-group-form__field--left
-      = f.label :name, class: 'chat-group-form__label'
+      = f.label :name, class: 'chat-group-form__label', value: "グループ名"
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field


### PR DESCRIPTION
# what
グループ作成画面のグループ名を入力する項目名を「グループ名」に変更。

# why
グループ名が「Name」になっていたため。