### PR TITLE
グループ編集機能　バグ修正

### DIFF
--- a/app/assets/stylesheets/modules/_group.scss
+++ b/app/assets/stylesheets/modules/_group.scss
@@ -6,7 +6,6 @@ h1 {
 }
 h2 {
   margin-bottom: 10px;
-  color: #f05050;
   font-size: 14px;
 }
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -25,7 +25,7 @@ class GroupsController < ApplicationController
     if @group.update(group_params)
       redirect_to group_messages_path(@group.id), notice: 'グループを更新しました'
     else
-      render edit
+      render :edit
     end
   end
 

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -17,7 +17,7 @@
     = form_for [@group, @message] do |f|
       .form__new
         .form__new__input
-          = f.text_field :text, class: 'form__new__input__message', placeholder: "input a message"
+          = f.text_field :text, class: 'form__new__input__message', placeholder: "type a message"
           = f.label :image, class: 'form__new__input__picture' do
             = icon('far', 'image')
             = f.file_field :image, class: 'form__new__input__picture--file'


### PR DESCRIPTION
# what
1. グループ編集機能にバグがあったため。
2. 「Log in」と「Edit Account」の文字色がサンプルと異なっていたため。
3. メッセージ送信フォーム内の文言がサンプルと異なっていたため。

# why
1のバグの修正は必須であるが、2と3はついでに修正しておく。